### PR TITLE
Aerobridge Guardian (trusted flight module) : JWT verification for flights / vehicle arming

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "modules/CrashDebug"]
 	path = modules/CrashDebug
 	url = https://github.com/adamgreen/CrashDebug
+[submodule "modules/libguardian"]
+	path = modules/libguardian
+	url = https://github.com/Thalhammer/jwt-cpp.git

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -15,6 +15,33 @@ void AP_Arming_Copter::update(void)
         display_fail = true;
         pre_arm_display_counter = 0;
     }
+    //a sample verification token
+    std::string rsa_pub_key = R"(-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuGbXWiK3dQTyCbX5xdE4
+yCuYp0AF2d15Qq1JSXT/lx8CEcXb9RbDddl8jGDv+spi5qPa8qEHiK7FwV2KpRE9
+83wGPnYsAm9BxLFb4YrLYcDFOIGULuk2FtrPS512Qea1bXASuvYXEpQNpGbnTGVs
+WXI9C+yjHztqyL2h8P6mlThPY9E9ue2fCqdgixfTFIF9Dm4SLHbphUS2iw7w1JgT
+69s7of9+I9l5lsJ9cozf1rxrXX4V1u/SotUuNB3Fp8oB4C1fLBEhSlMcUJirz1E8
+AziMCxS+VrRPDM+zfvpIJg3JljAh3PJHDiLu902v9w+Iplu1WyoB2aPfitxEhRN0
+YwIDAQAB
+-----END PUBLIC KEY-----)";
+
+	std::string token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9."
+						"VA2i1ui1cnoD6I3wnji1WAVCf29EekysvevGrT2GXqK1dDMc8"
+						"HAZCTQxa1Q8NppnpYV-hlqxh-X3Bb0JOePTGzjynpNZoJh2aHZD-"
+						"GKpZt7OO1Zp8AFWPZ3p8Cahq8536fD8RiBES9jRsvChZvOqA7gMcFc4"
+						"YD0iZhNIcI7a654u5yPYyTlf5kjR97prCf_OXWRn-bYY74zna4p_bP9oWCL4BkaoRcMxi-"
+						"IR7kmVcCnvbYqyIrKloXP2qPO442RBGqU7Ov9"
+						"sGQxiVqtRHKXZR9RbfvjrErY1KGiCp9M5i2bsUHadZEY44FE2jiOmx-"
+						"uc2z5c05CCXqVSpfCjWbh9gQ";
+
+	auto verify =
+		jwt::verify().allow_algorithm(jwt::algorithm::rs256(rsa_pub_key, "", "", "")).with_issuer("auth0");
+
+	auto decoded = jwt::decode(token);
+
+	verify.verify(decoded);
+
 
     pre_arm_checks(display_fail);
 }

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -1,6 +1,12 @@
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wshadow" 
+#pragma GCC disgnostic pop
+
 #include <AP_Arming/AP_Arming.h>
+#include <jwt-cpp/jwt.h>
 
 class AP_Arming_Copter : public AP_Arming
 {

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -358,11 +358,17 @@ class Board:
                 cfg.srcnode.find_dir('modules/uavcan/libuavcan/include').abspath()
             ]
 
+        env.INCLUDES += [
+            cfg.srcnode.find_dir('modules/libguardian/include/').abspath()
+        ]
+        env.CXXFLAGS += [
+            '-fexceptions' 
+        ] 
         if cfg.options.build_dates:
             env.build_dates = True
 
         # We always want to use PRI format macros
-        cfg.define('__STDC_FORMAT_MACROS', 1)
+        cfg.define('__STDC_FORMAT_MACROS_', 1)
 
         if cfg.options.disable_ekf2:
             env.CXXFLAGS += ['-DHAL_NAVEKF2_AVAILABLE=0']
@@ -548,6 +554,9 @@ class sitl(Board):
 
         env.LIB += [
             'm',
+            'ssl',
+            'crypto',
+            'dl'
         ]
 
         cfg.check_librt(env)

--- a/libraries/SITL/picojson.h
+++ b/libraries/SITL/picojson.h
@@ -95,7 +95,7 @@ extern "C" {
 
 // experimental support for int64_t (see README.mkdn for detail)
 #ifdef PICOJSON_USE_INT64
-#define __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS_
 #include <cerrno>
 #if __cplusplus >= 201103L
 #include <cinttypes>


### PR DESCRIPTION
This is an initial PR for verifying the JWT signature received at the firmware from the ground control station (GCS). Post successful verification, drone arming can be performed. 

Work done:

- Added [jwt-cpp](https://github.com/Thalhammer/jwt-cpp) as a submodule to leverage the APIs provided by the library for verification.
- Worked on proper integration: changes to the environment variables for a proper build.
- Added a sample script in `AP_Arming.cpp` for verification using the library's APIs. 

Future Work:

- The permission artifact would be present on the drone SD card. We need to find a workaround for successfully fetching that file.
- Parsing the file, obtaining the signature, verification, and arming decision.

Let me know if you have any suggestions.
Thanks.